### PR TITLE
Implement two-layer perceptron learning rule

### DIFF
--- a/lab1/lab1.py
+++ b/lab1/lab1.py
@@ -16,9 +16,10 @@ np.random.seed(42)
 
 # Flags to decide which part of  the program should be run
 SHOW_DATA_SCATTER_PLOT = False
-APPLY_DELTA_RULE_BATCH = True
-APPLY_DELTA_RULE_SEQUENTIAL = True
+APPLY_DELTA_RULE_BATCH = False
+APPLY_DELTA_RULE_SEQUENTIAL = False
 APPLY_PERCEPTRON_LEARNING_RULE = False
+APPLY_TWO_LAYER_PERCEPTRON_LEARNING_RULE = True
 
 
 def generate_data(n, mA, sigmaA, mB, sigmaB):
@@ -233,6 +234,153 @@ class Perceptron:
                     self.W, title="Perceptron Learning Decision Boundary")
 
 
+class TwoLayerPerceptron:
+    """The two-layer perceptron trained with backprop (the generalized Delta
+    Rule)"""
+    def __init__(self, h=4, epochs=100, eta=0.001):
+        """Class constructor
+
+        Args:
+            h (int): Number of hidden layers
+            epochs (int): Number of training epochs
+            eta (float): The learning rate
+        """
+        self.h = h
+        self.epochs = epochs
+        self.eta = eta
+
+
+    def initialize_weights(self, X, t):
+        """Initialize the weight matrices
+
+        Args:
+            X (np.ndarray): Observations of shape (n, d)
+            t (np.ndarray): Targets of shape (n, 1)
+
+        Returns:
+            None
+        """
+        n = X.shape[0] # Number of data points
+        d = X.shape[1] # Dimensionality of data point
+
+        # Initialize the weights
+        self.V = np.random.normal(0, 1/np.sqrt(d), (d, self.h))
+        self.W = np.random.normal(0, 1/np.sqrt(self.h), (self.h, 1))
+
+
+    @staticmethod
+    def _activation_function(x):
+        """Computes the non-linear activation function
+
+        Args:
+            x {float or np.ndarray}: Input to be transformed
+
+        Returns:
+            (float or np.ndarray): Output
+        """
+        return 2 / (1 + np.exp(-x)) - 1
+
+
+    @staticmethod
+    def _d_activation_function(x):
+        """Computes the derivative of the non-linear activation function
+
+        Args:
+            x {float or np.ndarray}: Input transformed by non-linear activation
+
+        Returns:
+            (float or np.ndarray): Output
+
+        """
+        return np.multiply((1+ x), (1-x)) / 2
+
+
+    def forward_pass(self, X):
+        """ Forward pass of the baackprop algorithm
+
+        Args:
+            X (np.ndarray): The input data
+
+        Returns:
+            h (np.ndarray): Output of the hidden layer
+            o (np.ndarray): Final output
+        """
+        h = self._activation_function(X @ self.V)
+        o = self._activation_function(h @ self.W)
+
+        return h, o
+
+
+    def predict(self, X, threshold=0):
+        """Multilayer perceptron prediction function
+
+        Args:
+            X (np.ndarray): Observations to be predicted
+            threshold (float): Classification threshold
+
+        Returns:
+            X (np.ndarray): Matrix of predictions corresponding to X
+        """
+        X[X >= threshold] = 1
+        X[X < threshold] = -1
+
+        return X
+
+
+    def compute_accuracy(self, X, t):
+        """Calculate training/testing accuracy
+
+        Args:
+            X (np.ndarray): Observations of shape (n, d)
+            t (np.ndarray): Targets of shape (n, 1)
+
+        Returns:
+           (float): The accuracy
+        """
+        # Make a prediction based on the perceptron's output
+        p = self.predict(self.forward_pass(X)[1])
+
+        return 1 - np.mean(p != t)
+
+
+    def train(self, X, t, print_acc=False):
+        """Train the two-layer perceptron
+
+        Args:
+            X (np.ndarray): Observations of shape (n, d)
+            t (np.ndarray): Targets of shape (n, 1)
+            print_acc (bool): Flag to specify whether to print the accuracy
+                              after each epoch
+
+        Returns:
+            None
+        """
+        # Initialize weights based on dimensions of observations and targets
+        self.initialize_weights(X, t)
+
+        for e in range(self.epochs):
+            # Forward pass
+            h, o = self.forward_pass(X)
+
+            # Backward pass
+            delta_o = np.multiply((o - t), self._d_activation_function(o))
+            delta_h = np.multiply(delta_o @ self.W.T,
+                    self._d_activation_function(h))
+
+            # Update the weights
+            self.V += - self.eta * X.T @ delta_h
+            self.W += - self.eta * h.T @ delta_o
+
+            # Compute the accuracy
+            acc = self.compute_accuracy(X, t)
+            if print_acc:
+                print(f'The accuracy after epoch {e}: {acc}')
+
+            if acc == 1.0:
+                print((f'Complete convergence after {e} epochs.'))
+                break
+
+
 # Generate toy-data
 classA, classB = generate_data(n=100, mA=[1.0, 1.0], sigmaA=0.4,
         mB=[-1.0, -0.5], sigmaB=0.4)
@@ -254,4 +402,8 @@ if APPLY_DELTA_RULE_SEQUENTIAL:
 if APPLY_PERCEPTRON_LEARNING_RULE:
     perceptron = Perceptron()
     perceptron.train(X, t, animate=True)
+
+if APPLY_TWO_LAYER_PERCEPTRON_LEARNING_RULE:
+    clf = TwoLayerPerceptron()
+    clf.train(X, t, print_acc=True)
 

--- a/lab1/lab1.py
+++ b/lab1/lab1.py
@@ -241,7 +241,7 @@ class TwoLayerPerceptron:
         """Class constructor
 
         Args:
-            h (int): Number of hidden layers
+            h (int): Number of hidden nodes
             epochs (int): Number of training epochs
             eta (float): The learning rate
         """
@@ -260,8 +260,8 @@ class TwoLayerPerceptron:
         Returns:
             None
         """
-        n = X.shape[0] # Number of data points
-        d = X.shape[1] # Dimensionality of data point
+        # Number of data poitns and the dimensionality of data points
+        n, d = X.shape[0], X.shape[1]
 
         # Initialize the weights
         self.V = np.random.normal(0, 1/np.sqrt(d), (d, self.h))


### PR DESCRIPTION
After trying to implement the two-layer perceptron, things seem to work:

Some remarks:

- The naming conventions from Pawel's slides on multi-layer perceptrons were used, since the ones used in the assignment seem more confusing.
- The only test that I have done to determine whether the algorithm works is to print the training accuracy after each epoch and see whether it converges, which is not the most rigorous of tests.
- Weight-updating with momentum has not been implemented yet
- As of yet, none of the experiments mentioned in section 3.2.1 have been carried out