### PR TITLE
Feat/implement greedy layer wise training

### DIFF
--- a/lab4/code/run.py
+++ b/lab4/code/run.py
@@ -16,6 +16,8 @@ from rbm import RestrictedBoltzmannMachine
 from dbn import DeepBeliefNet
 
 PLOTS = False
+RBM = False
+DBN = True
 
 if __name__ == "__main__":
     # Fix the dimensions of the images
@@ -46,28 +48,31 @@ if __name__ == "__main__":
             plot_digit(train_imgs[i], train_lbls_digits[i])
 
 
-    # Restricted Boltzmann Machine
-    print ("\nStarting a Restricted Boltzmann Machine...")
+    if RBM:
+        # Restricted Boltzmann Machine
+        print ("\nStarting a Restricted Boltzmann Machine...")
 
-    rbm = RestrictedBoltzmannMachine(ndim_visible=image_size[0] * image_size[1],
-            ndim_hidden=200, is_bottom=True, image_size=image_size, is_top=False,
-            n_labels=10, batch_size=20, learning_rate=0.1)
+        rbm = RestrictedBoltzmannMachine(ndim_visible=image_size[0] * image_size[1],
+                ndim_hidden=200, is_bottom=True, image_size=image_size, is_top=False,
+                n_labels=10, batch_size=20, learning_rate=0.1)
 
-    rbm.cd1(X=train_imgs, n_iterations=30000)
+        rbm.cd1(X=train_imgs, n_iterations=30000)
 
-    # We do not always want to run everything in this main file
-    if False:
+    if DBN:
         # Deep Belief Net
-        print ("\nStarting a Deep Belief Net...")
+        print ("\n>>> Starting a Deep Belief Net...")
 
-        dbn = DeepBeliefNet(sizes={"vis":image_size[0]*image_size[1], "hid":500,
-            "pen":500, "top":2000, "lbl":10}, image_size=image_size, n_labels=10,
-            batch_size=10)
+        dbn = DeepBeliefNet(sizes={"vis": image_size[0] * image_size[1],
+            "hid": 500, "pen": 500, "top": 2000, "lbl": 10},
+            image_size=image_size, n_labels=10, batch_size=10)
 
         # Greedy layer-wise training
-        dbn.train_greedylayerwise(vis_trainset=train_imgs, lbl_trainset=train_lbls,
+        dbn.train_greedylayerwise(vis_trainset=train_imgs[:4000, :],
+                lbl_trainset=train_lbls[:4000, :],
                 n_iterations=2000)
 
+    # This has not been implemented yet
+    if False:
         dbn.recognize(train_imgs, train_lbls)
         dbn.recognize(test_imgs, test_lbls)
 


### PR DESCRIPTION
The following has been done in this update:

- ```rbm.py````has been modified such that it can function as a bottom, intermediate, or top layer in a DBN. Special attention should be given to the function ```get_v_given_h()``` in the case that ```self.is_top == True```; in that case, the slice of ```H_batch``` corresponding to the labels has to be activated and sampled differently than the slice corresponding to the data. Also, the reconstruction loss should only be computed based on the data, not on the labels! @Stellakats this is why we saw the reconstruction loss shooting up to infinity in the top layer.
- ```dbn.py``` specifies the three diffferent RBM layers of our DBN. The hidden layer of the bottom layer is passed to the intermediate layer, whose hidden layer is subsequently passed to the top layer. After greedy layer-by-layer learning of the bottom and intermediate layer, their weight matrices can be untwined for the next part of the assignment.
- ````run.py``` in its current configuration performs greedy learning for 5 epochs per layer on the first 4000 images in the MNIST data set. More experimentation should be conducted to convince ourself that the current implementation is correct, but since the reconstruction error increases per epoch in each separate layer, it seems to work.

Make sure that you understand what I have done before moving on to the next part of the assignment. Do not hesitate to ask questions :)