### PR TITLE
Feat/wake sleep reimplemented

### DIFF
--- a/lab4/code/dbn.py
+++ b/lab4/code/dbn.py
@@ -243,9 +243,12 @@ class DeepBeliefNet():
             loc (str): The location of the file
             name (str): Name of RBM
         """
-        self.rbm_stack[name].weight_vh = np.load(f"{loc}/rbm.{name}.weight_vh.npy")
-        self.rbm_stack[name].bias_v    = np.load(f"{loc}/rbm.{name}.bias_v.npy")
-        self.rbm_stack[name].bias_h    = np.load(f"{loc}/rbm.{name}.bias_h.npy")
+        self.rbm_stack[name].weight_vh = np.load(f"{loc}/rbm.{name}.weight_vh.npy",
+                allow_pickle=True)
+        self.rbm_stack[name].bias_v    = np.load(f"{loc}/rbm.{name}.bias_v.npy",
+                allow_pickle=True)
+        self.rbm_stack[name].bias_h    = np.load(f"{loc}/rbm.{name}.bias_h.npy",
+                allow_pickle=True)
         print(f"Loaded rbm[{name}] from {loc}.")
 
 
@@ -268,9 +271,12 @@ class DeepBeliefNet():
             loc (str): The location of the file
             name (str): Name of RBM
         """
-        self.rbm_stack[name].weight_v_to_h = np.load(f"{loc}/dbn.{name}.weight_v_to_h.npy")
-        self.rbm_stack[name].weight_h_to_v = np.load(f"{loc}/dbn.{name}.weight_h_to_v.npy")
-        self.rbm_stack[name].bias_v        = np.load(f"{loc}/dbn.{name}.bias_v.npy")
+        self.rbm_stack[name].weight_v_to_h = np.load(f"{loc}/dbn.{name}.weight_v_to_h.npy",
+                allow_pickle=True)
+        self.rbm_stack[name].weight_h_to_v = np.load(f"{loc}/dbn.{name}.weight_h_to_v.npy",
+                allow_pickle=True)
+        self.rbm_stack[name].bias_v        = np.load(f"{loc}/dbn.{name}.bias_v.npy",
+                allow_pickle=True)
         self.rbm_stack[name].bias_h        = np.load(f"{loc}/dbn.{name}.bias_h.npy")
         print(f"Loaded rbm[{name}] from {loc}.")
 

--- a/lab4/code/dbn.py
+++ b/lab4/code/dbn.py
@@ -54,7 +54,8 @@ class DeepBeliefNet():
         self.n_gibbs_recog = 15
         self.n_gibbs_gener = 200
         self.n_gibbs_wakesleep = 5
-        self.print_period = 2000
+        self.n_labels = n_labels
+        self.reconstruction_errors = []
 
 
     def recognize(self, X, y):
@@ -151,8 +152,8 @@ class DeepBeliefNet():
                 "plots_and_animations/%s.generate%d.mp4" % (name,np.argmax(y)))
 
 
-    def train_greedylayerwise(self, X, y, n_iterations,
-            load_from_file=False, save_to_file=False):
+    def train_greedylayerwise(self, X, y, n_iterations, load_from_file=False,
+            save_to_file=False, compute_rec_err=False):
         """Greedy layer-wise training by stacking RBMs.
 
         Notice that once you stack more layers on top of a RBM, the weights are
@@ -167,6 +168,7 @@ class DeepBeliefNet():
                               learns a mini-batch)
           load_from_file (bool): Whether to load from file
           save_to_file (bool): Whether to save to file
+        compute_rec_err (bool): Whether to compute the reconstruction error
         """
         if load_from_file:
             self.loadfromfile_rbm(loc="trained_rbm", name="vis--hid")
@@ -182,7 +184,12 @@ class DeepBeliefNet():
             print ("\n>> Training RBM vis--hid...")
 
             # Learn the weights of the vis--hid RBM by means of CD1
-            self.rbm_stack["vis--hid"].cd1(X, n_iterations=n_iterations)
+            if compute_rec_err:
+                err = self.rbm_stack["vis--hid"].cd1(X, n_iterations=n_iterations,
+                        compute_rec_err=compute_rec_err)
+                self.reconstruction_errors.append(err)
+            else:
+                self.rbm_stack["vis--hid"].cd1(X, n_iterations=n_iterations)
 
             # Save layer represenetations to file if requested
             if save_to_file: self.savetofile_rbm(loc="trained_rbm",
@@ -196,8 +203,13 @@ class DeepBeliefNet():
             print ("\n>> Training RBM hid--pen...")
 
             # Learn the weights of the hid--pen RBM by means of CD1
-            self.rbm_stack["hid--pen"].cd1(self.rbm_stack["vis--hid"].H,
-                    n_iterations=n_iterations)
+            if compute_rec_err:
+                err = self.rbm_stack["hid--pen"].cd1(self.rbm_stack["vis--hid"].H,
+                        n_iterations=n_iterations, compute_rec_err=compute_rec_err)
+                self.reconstruction_errors.append(err)
+            else:
+                self.rbm_stack["hid--pen"].cd1(self.rbm_stack["vis--hid"].H,
+                        n_iterations=n_iterations)
 
             # Save layer represenetations to file if requested
             if save_to_file: self.savetofile_rbm(loc="trained_rbm",

--- a/lab4/code/dbn.py
+++ b/lab4/code/dbn.py
@@ -150,15 +150,15 @@ class DeepBeliefNet():
         permanently untwined.
 
         Args:
-          X (np.ndarray): Visible data shaped (size of training set,
-                          size of visible layer)
-          y (np.ndarray): Label data shaped (size of training set,
-                          size of label layer)
-          n_iterations (int): Number of iterations of learning (each iteration
-                              learns a mini-batch)
-          load_from_file (bool): Whether to load from file
-          save_to_file (bool): Whether to save to file
-        compute_rec_err (bool): Whether to compute the reconstruction error
+            X (np.ndarray): Visible data shaped (size of training set,
+                            size of visible layer)
+            y (np.ndarray): Label data shaped (size of training set,
+                            size of label layer)
+            n_iterations (int): Number of iterations of learning (each iteration
+                                learns a mini-batch)
+            load_from_file (bool): Whether to load from file
+            save_to_file (bool): Whether to save to file
+            compute_rec_err (bool): Whether to compute the reconstruction error
         """
         if load_from_file:
             self.loadfromfile_rbm(loc="trained_rbm", name="vis--hid")

--- a/lab4/code/dbn.py
+++ b/lab4/code/dbn.py
@@ -67,20 +67,16 @@ class DeepBeliefNet():
                           size of label layer). Used only for calculating
                           accuracy, not driving the net
         """
-        n_samples = X.shape[0]
         y_init = np.ones(y.shape) * 0.1 # Uninformed labels
 
         # Specify the vis--hid RBM
         vis__hid = self.rbm_stack["vis--hid"]
-        vis__hid.bias_h = vis__hid.bias_h.reshape(-1, 1)
 
         # Specify the hid--pen RBM
         hid__pen = self.rbm_stack["hid--pen"]
-        hid__pen.bias_h.reshape(-1, 1)
 
         # Specify the pen+lbl--top RBM
         pen_lbl__top = self.rbm_stack["pen+lbl--top"]
-        pen_lbl__top.bias_h.reshape(-1, 1)
 
         # Forward propagation through the network
         fp_bottom_h_prob, fp_bottom_h_state = vis__hid.get_h_given_v(X,

--- a/lab4/code/dbn.py
+++ b/lab4/code/dbn.py
@@ -117,7 +117,7 @@ class DeepBeliefNet():
         h_prob, h_state = hid__pen.get_h_given_v(h_prob, directed=True,
                 direction="up")
 
-        v_state = np.hstack((h_state, y))
+        v_state = np.hstack((h_state.reshape(1, -1), y))
 
         # Perform Gibbs sampling
         for it in range(self.n_gibbs_gener):
@@ -129,12 +129,12 @@ class DeepBeliefNet():
                 v_state_data_only = np.copy(v_state[:, :-10])
 
                 # Backward propagation
-                h_prob, _h_state = hid__pen.get_v_given_h(v_state_data_only,
+                h_prob, h_state = hid__pen.get_v_given_h(v_state_data_only,
                         directed=True, direction="down")
                 h_prob, h_state = vis__hid.get_v_given_h(h_state, directed=True,
                         direction="down")
 
-                records.append([ax.imshow(np.mean(bp_vis_h_prob, axis=0).reshape(
+                records.append([ax.imshow(np.mean(h_prob, axis=0).reshape(
                     self.image_size), cmap="bwr", vmin=0, vmax=1, animated=True,
                     interpolation=None)])
 
@@ -248,9 +248,9 @@ class DeepBeliefNet():
         """
         print("\n> Training wake-sleep...")
         if load_from_file:
-            self.loadfromfile_dbn(loc="trained_dbn_4pm", name="vis--hid")
-            self.loadfromfile_dbn(loc="trained_dbn_4pm", name="hid--pen")
-            self.loadfromfile_rbm(loc="trained_dbn_4pm", name="pen+lbl--top")
+            self.loadfromfile_dbn(loc="trained_dbn", name="vis--hid")
+            self.loadfromfile_dbn(loc="trained_dbn", name="hid--pen")
+            self.loadfromfile_rbm(loc="trained_dbn", name="pen+lbl--top")
 
         else:
             # Specify the RBMs

--- a/lab4/code/dbn.py
+++ b/lab4/code/dbn.py
@@ -169,13 +169,13 @@ class DeepBeliefNet():
           save_to_file (bool): Whether to save to file
         """
         if load_from_file:
-            self.loadfromfile_rbm(loc="trained_rbm_4pm", name="vis--hid")
+            self.loadfromfile_rbm(loc="trained_rbm", name="vis--hid")
             self.rbm_stack["vis--hid"].untwine_weights()
 
-            self.loadfromfile_rbm(loc="trained_rbm_4pm", name="hid--pen")
+            self.loadfromfile_rbm(loc="trained_rbm", name="hid--pen")
             self.rbm_stack["hid--pen"].untwine_weights()
 
-            self.loadfromfile_rbm(loc="trained_rbm_4pm", name="pen+lbl--top")
+            self.loadfromfile_rbm(loc="trained_rbm", name="pen+lbl--top")
 
         else:
             ## RBM VIS--HID

--- a/lab4/code/dbn.py
+++ b/lab4/code/dbn.py
@@ -223,13 +223,23 @@ class DeepBeliefNet():
             print ("\n>> Training layer pen+lbl--top...")
 
             # Learn the weights of the pen+lbl--top RBM by means of CD1
-            self.rbm_stack["pen+lbl--top"].cd1(np.hstack(
-                (self.rbm_stack["hid--pen"].H, y)),
-                n_iterations=n_iterations)
+            if compute_rec_err:
+                err = self.rbm_stack["pen+lbl--top"].cd1(np.hstack(
+                    (self.rbm_stack["hid--pen"].H, y)), n_iterations=n_iterations,
+                    compute_rec_err=compute_rec_err)
+                self.reconstruction_errors.append(err)
+            else:
+                self.rbm_stack["pen+lbl--top"].cd1(np.hstack(
+                    (self.rbm_stack["hid--pen"].H, y)),
+                    n_iterations=n_iterations)
 
             # Save layer represenetations to file if requested
             if save_to_file: self.savetofile_rbm(loc="trained_rbm",
                     name="pen+lbl--top")
+
+            if compute_rec_err:
+                plot_reconstruction_err(self.reconstruction_errors,
+                        fname="plots_and_animations/errors.pdf", save_fig=True)
 
 
     def train_wakesleep_finetune(self, X, y, n_iterations,

--- a/lab4/code/dbn.py
+++ b/lab4/code/dbn.py
@@ -70,25 +70,21 @@ class DeepBeliefNet():
         """
         y_init = np.ones(y.shape) * 0.1 # Uninformed labels
 
-        # Specify the vis--hid RBM
+        # Specify the RBMS
         vis__hid = self.rbm_stack["vis--hid"]
-
-        # Specify the hid--pen RBM
         hid__pen = self.rbm_stack["hid--pen"]
-
-        # Specify the pen+lbl--top RBM
         pen_lbl__top = self.rbm_stack["pen+lbl--top"]
 
         # Forward propagation through the network
-        fp_bottom_h_prob, fp_bottom_h_state = vis__hid.get_h_given_v(X,
-                directed=True, direction="up")
-        fp_interm_h_prob, fp_interm_h_state = hid__pen.get_h_given_v(
-                fp_bottom_h_prob, directed=True, direction="up")
+        h_prob, h_state = vis__hid.get_h_given_v(X, directed=True,
+                direction="up")
+        h_prob, h_state = hid__pen.get_h_given_v(h_prob, directed=True,
+                direction="up")
 
         # Perform alternating Gibbs sampling
-        v_state = np.hstack((fp_interm_h_state, y_init))
+        v_prob = np.hstack((h_prob, y_init))
         for _ in range(self.n_gibbs_recog):
-            h_prob, h_state = pen_lbl__top.get_h_given_v(v_state)
+            h_prob, h_state = pen_lbl__top.get_h_given_v(v_prob)
             v_prob, v_state = pen_lbl__top.get_v_given_h(h_state)
 
         y_pred = v_state[:, -10:]

--- a/lab4/code/dbn.py
+++ b/lab4/code/dbn.py
@@ -254,14 +254,16 @@ class DeepBeliefNet():
             for it in range(n_iterations):
                 ## Wake-phase
                 # RBM vis__hid
-                v, vold = X, v
+                v = X
+                vold = v
 
                 ph, h = vis__hid.get_h_given_v(v, directed=True, direction="up")
                 pv, v = vis__hid.get_v_given_h(h, directed=True, direction="down")
                 vis__hid.update_generate_params(vold, h, pv)
 
                 # RBM hid__pen
-                v, vold = h, v
+                v = h
+                vold = v
 
                 ph, h = hid__pen.get_h_given_v(v, directed=True, direction="up")
                 pv, v = hid__pen.get_v_given_h(h, directed=True, direction="down")
@@ -280,14 +282,16 @@ class DeepBeliefNet():
 
                 ## Sleep-phase
                 # RBM hid__pen
-                h, hold = v, h
+                h = v
+                hold = h
 
                 pv, v = hid__pen.get_v_given_h(h, directed=True, direction="down")
                 ph, h = hid__pen.get_h_given_v(v, directed=True, direction="up")
                 hid__pen.update_recognize_params(hold, v, ph)
 
                 # RBM vis__hid
-                h, hold = v, h
+                h = v
+                hold = h
 
                 pv, v = vis__hid.get_v_given_h(h, directed=True, direction="down")
                 ph, h = vis__hid.get_h_given_v(v, directed=True, direction="up")

--- a/lab4/code/dbn.py
+++ b/lab4/code/dbn.py
@@ -96,28 +96,59 @@ class DeepBeliefNet():
             y_pred, axis=1) == np.argmax(y, axis=1))))
 
 
-    def generate(self, true_lbl, name):
+    def generate(self, X, y, name):
         """Generate data from labels
 
         Args:
-          true_lbl (np.ndarray): true labels shaped (number of samples,
-                                 size of label layer)
+          y (np.ndarray): true labels shaped (number of samples,
+                          number of classes)
           name (str): used for saving a video of generated visible activations
         """
-        n_sample, records = true_lbl.shape[0], []
+        n_sample, records = y.shape[0], []
         fig, ax = plt.subplots(1, 1, figsize=(3, 3))
         plt.subplots_adjust(left=0, bottom=0, right=1, top=1, wspace=0, hspace=0)
         ax.set_xticks([]); ax.set_yticks([])
 
-        lbl = true_lbl
+        # Specify the vis--hid RBM
+        vis__hid = self.rbm_stack["vis--hid"]
 
-        for _ in range(self.n_gibbs_gener):
-            vis = np.random.rand(n_sample, self.sizes["vis"])
-            records.append([ax.imshow(vis.reshape(self.image_size), cmap="bwr",
-                vmin=0, vmax=1, animated=True, interpolation=None)])
+        # Specify the hid--pen RBM
+        hid__pen = self.rbm_stack["hid--pen"]
 
-        anim = stitch_video(fig,records).save("plots_and_animations/%s.generate%d.mp4" %
-                (name,np.argmax(true_lbl)))
+        # Specify the pen+lbl--top RBM
+        pen_lbl__top = self.rbm_stack["pen+lbl--top"]
+
+        # Forward propagation through the network
+        fp_bottom_h_prob, fp_bottom_h_state = vis__hid.get_h_given_v(X,
+                directed=True, direction="up")
+        fp_interm_h_prob, fp_interm_h_state = hid__pen.get_h_given_v(
+                fp_bottom_h_prob, directed=True, direction="up")
+
+        # Perform alternating Gibbs sampling
+        y = np.repeat(y, X.shape[0], axis=0)
+        v_state = np.hstack((fp_interm_h_state, y))
+
+        # Perform Gibbs sampling
+        for it in range(self.n_gibbs_gener):
+            h_prob, h_state = pen_lbl__top.get_h_given_v(v_state)
+            v_prob, v_state = pen_lbl__top.get_v_given_h(h_state)
+            v_state[:, -10:] = y # fix y
+
+            if it % 10 == 0:
+                v_state_data_only = np.copy(v_state[:, :-10])
+
+                # Backward propagation
+                bp_hid_h_prob, bp_hid_h_state = hid__pen.get_v_given_h(v_state_data_only,
+                        directed=True, direction="down")
+                bp_vis_h_prob, bp_vis_h_state = vis__hid.get_v_given_h(bp_hid_h_state,
+                        directed=True, direction="down")
+
+                records.append([ax.imshow(np.mean(bp_vis_h_prob, axis=0).reshape(
+                    self.image_size), cmap="bwr", vmin=0, vmax=1, animated=True,
+                    interpolation=None)])
+
+            anim = stitch_video(fig,records).save("plots_and_animations/%s.generate%d.mp4" %
+                    (name,np.argmax(y)))
 
 
     def train_greedylayerwise(self, X, y, n_iterations,

--- a/lab4/code/dbn.py
+++ b/lab4/code/dbn.py
@@ -294,7 +294,7 @@ class DeepBeliefNet():
                 v = h
 
                 # Training the top RBM with CD1
-                pen_lbl__top.cd1(np.hstack((v, y)), 60000)
+                pen_lbl__top.cd1(np.hstack((v, y)), X.shape[0])
 
                 ## Alternating Gibbs sampling in the top RBM
                 for _ in range(self.n_gibbs_wakesleep):

--- a/lab4/code/dbn.py
+++ b/lab4/code/dbn.py
@@ -138,17 +138,17 @@ class DeepBeliefNet():
                 v_state_data_only = np.copy(v_state[:, :-10])
 
                 # Backward propagation
-                bp_hid_h_prob, bp_hid_h_state = hid__pen.get_v_given_h(v_state_data_only,
-                        directed=True, direction="down")
-                bp_vis_h_prob, bp_vis_h_state = vis__hid.get_v_given_h(bp_hid_h_state,
-                        directed=True, direction="down")
+                bp_hid_h_prob, bp_hid_h_state = hid__pen.get_v_given_h(
+                        v_state_data_only, directed=True, direction="down")
+                bp_vis_h_prob, bp_vis_h_state = vis__hid.get_v_given_h(
+                        bp_hid_h_state, directed=True, direction="down")
 
                 records.append([ax.imshow(np.mean(bp_vis_h_prob, axis=0).reshape(
                     self.image_size), cmap="bwr", vmin=0, vmax=1, animated=True,
                     interpolation=None)])
 
-            anim = stitch_video(fig,records).save("plots_and_animations/%s.generate%d.mp4" %
-                    (name,np.argmax(y)))
+            anim = stitch_video(fig,records).save(
+                "plots_and_animations/%s.generate%d.mp4" % (name,np.argmax(y)))
 
 
     def train_greedylayerwise(self, X, y, n_iterations,
@@ -169,13 +169,13 @@ class DeepBeliefNet():
           save_to_file (bool): Whether to save to file
         """
         if load_from_file:
-            self.loadfromfile_rbm(loc="trained_rbm", name="vis--hid")
+            self.loadfromfile_rbm(loc="trained_rbm_4pm", name="vis--hid")
             self.rbm_stack["vis--hid"].untwine_weights()
 
-            self.loadfromfile_rbm(loc="trained_rbm", name="hid--pen")
+            self.loadfromfile_rbm(loc="trained_rbm_4pm", name="hid--pen")
             self.rbm_stack["hid--pen"].untwine_weights()
 
-            self.loadfromfile_rbm(loc="trained_rbm", name="pen+lbl--top")
+            self.loadfromfile_rbm(loc="trained_rbm_4pm", name="pen+lbl--top")
 
         else:
             ## RBM VIS--HID
@@ -285,9 +285,9 @@ class DeepBeliefNet():
         """
         self.rbm_stack[name].weight_vh = np.load(f"{loc}/rbm.{name}.weight_vh.npy",
                 allow_pickle=True)
-        self.rbm_stack[name].bias_v    = np.load(f"{loc}/rbm.{name}.bias_v.npy",
+        self.rbm_stack[name].bias_v = np.load(f"{loc}/rbm.{name}.bias_v.npy",
                 allow_pickle=True)
-        self.rbm_stack[name].bias_h    = np.load(f"{loc}/rbm.{name}.bias_h.npy",
+        self.rbm_stack[name].bias_h = np.load(f"{loc}/rbm.{name}.bias_h.npy",
                 allow_pickle=True)
         print(f"Loaded rbm[{name}] from {loc}.")
 
@@ -311,13 +311,13 @@ class DeepBeliefNet():
             loc (str): The location of the file
             name (str): Name of RBM
         """
-        self.rbm_stack[name].weight_v_to_h = np.load(f"{loc}/dbn.{name}.weight_v_to_h.npy",
+        self.rbm_stack[name].weight_v_to_h = \
+                np.load(f"{loc}/dbn.{name}.weight_v_to_h.npy", allow_pickle=True)
+        self.rbm_stack[name].weight_h_to_v = \
+                np.load(f"{loc}/dbn.{name}.weight_h_to_v.npy", allow_pickle=True)
+        self.rbm_stack[name].bias_v = np.load(f"{loc}/dbn.{name}.bias_v.npy",
                 allow_pickle=True)
-        self.rbm_stack[name].weight_h_to_v = np.load(f"{loc}/dbn.{name}.weight_h_to_v.npy",
-                allow_pickle=True)
-        self.rbm_stack[name].bias_v        = np.load(f"{loc}/dbn.{name}.bias_v.npy",
-                allow_pickle=True)
-        self.rbm_stack[name].bias_h        = np.load(f"{loc}/dbn.{name}.bias_h.npy")
+        self.rbm_stack[name].bias_h = np.load(f"{loc}/dbn.{name}.bias_h.npy")
         print(f"Loaded rbm[{name}] from {loc}.")
 
 
@@ -328,8 +328,10 @@ class DeepBeliefNet():
             loc (str): The location of the file
             name (str): Name of RBM
         """
-        np.save(f"{loc}/dbn.{name}.weight_v_to_h", self.rbm_stack[name].weight_v_to_h)
-        np.save(f"{loc}/dbn.{name}.weight_h_to_v", self.rbm_stack[name].weight_h_to_v)
-        np.save(f"{loc}/dbn.{name}.bias_v",        self.rbm_stack[name].bias_v)
-        np.save(f"{loc}/dbn.{name}.bias_h",        self.rbm_stack[name].bias_h)
+        np.save(f"{loc}/dbn.{name}.weight_v_to_h",
+                self.rbm_stack[name].weight_v_to_h)
+        np.save(f"{loc}/dbn.{name}.weight_h_to_v",
+                self.rbm_stack[name].weight_h_to_v)
+        np.save(f"{loc}/dbn.{name}.bias_v", self.rbm_stack[name].bias_v)
+        np.save(f"{loc}/dbn.{name}.bias_h", self.rbm_stack[name].bias_h)
 

--- a/lab4/code/rbm.py
+++ b/lab4/code/rbm.py
@@ -97,8 +97,9 @@ class RestrictedBoltzmannMachine():
         Returns:
             (np.ndarray): on_probabilities (size of mini-batch, number of categories)
         """
-        expsup = np.exp(support - np.sum(support, axis=1)[:, None])
-        return expsup / np.sum(expsup, axis=1)[:, None]
+        expsup = np.exp(support - np.max(support, axis=1)[:,None])
+
+        return expsup / expsup.sum(axis=1)[:, None]
 
 
     @staticmethod
@@ -133,6 +134,7 @@ class RestrictedBoltzmannMachine():
         activations = np.zeros(probabilities.shape)
         activations[range(probabilities.shape[0]),
                 np.argmax((cumsum >= rand), axis=1)] = 1
+
         return activations
 
 

--- a/lab4/code/rbm.py
+++ b/lab4/code/rbm.py
@@ -261,9 +261,11 @@ class RestrictedBoltzmannMachine():
             h_prob = self._sigmoid(self.bias_h + np.dot(X_batch, self.weight_vh))
         else:
             if direction == "up":
-                h_prob = self._sigmoid(self.bias_h.T + np.dot(X_batch, self.weight_v_to_h))
+                h_prob = self._sigmoid(self.bias_h + np.dot(
+                    X_batch, self.weight_v_to_h))
             elif direction == "down":
-                h_prob = self._sigmoid(self.bias_h + np.dot(X_batch, self.weight_h_to_v))
+                h_prob = self._sigmoid(self.bias_h + np.dot(
+                    X_batch, self.weight_h_to_v))
             else:
                 raise ValueError("Input argument <directed> has to be either 'up' or 'down'.")
 
@@ -272,11 +274,13 @@ class RestrictedBoltzmannMachine():
         return h_prob, h_state
 
 
-    def get_v_given_h(self, H_batch):
+    def get_v_given_h(self, H_batch, directed=False, direction="up"):
         """Compute probabilities p(v|h) and activations v ~ p(v|h)
 
         Args:
            H_batch: shape is (size of mini-batch, size of hidden layer)
+            directed (bool): Whether to use weight_v_to_h or weight_vh
+            direction (str): One of "up" or "down"
 
         Returns:
            v_prob (np.ndarray): p(v=1|h) (size mini-batch, size hidden layer)
@@ -302,8 +306,18 @@ class RestrictedBoltzmannMachine():
             v_state = np.hstack((v_state_data, v_state_labels))
 
         else:
-            v_prob = self._sigmoid(self.bias_v + np.dot(H_batch,
-                self.weight_vh.T))
+            if not directed:
+                v_prob = self._sigmoid(self.bias_v + np.dot(H_batch,
+                    self.weight_vh.T))
+            else:
+                if direction == "up":
+                    v_prob = self._sigmoid(self.bias_v + np.dot(
+                        H_batch, self.weight_v_to_h))
+                elif direction == "down":
+                    v_prob = self._sigmoid(self.bias_v + np.dot(
+                        H_batch, self.weight_h_to_v))
+                else:
+                    raise ValueError("Input argument <directed> has to be either 'up' or 'down'.")
 
             v_state = self._sample_binary(v_prob)
 

--- a/lab4/code/rbm.py
+++ b/lab4/code/rbm.py
@@ -57,7 +57,10 @@ class RestrictedBoltzmannMachine():
         self.bias_h = np.random.normal(loc=0.0, scale=0.01,
                 size=(self.ndim_hidden))
 
-        self.momentum = 0.7
+        self.d_weight_vh = np.zeros((self.ndim_visible,self.ndim_hidden))
+        self.d_bias_v = np.zeros((self.ndim_visible))
+        self.d_bias_h = np.zeros((self.ndim_hidden))
+        self.momentum = 0
         self.learning_rate = learning_rate
         self.image_size = image_size
 
@@ -228,13 +231,18 @@ class RestrictedBoltzmannMachine():
         Note: All args have shape (size of mini-batch, size of respective layer)
         Note: You could also add weight decay and momentum for weight updates.
         """
-        self.weight_vh += self.learning_rate * (np.dot(v0.T,
-            h0) - np.dot(v1.T, h1))
-        self.bias_v += self.learning_rate * np.mean(
-                v0 - v1, axis=0)
-        self.bias_h += self.learning_rate * np.mean(
-            h0 - h1, axis=0)
 
+        self.d_weight_vh = self.learning_rate * (np.dot(v0.T, h0) - np.dot(v1.T, h1))\
+                      + self.d_weight_vh * self.momentum
+        self.weight_vh += self.d_weight_vh
+
+        self.d_bias_v = self.learning_rate * np.mean(v0 - v1, axis=0)\
+                        + self.d_bias_v * self.momentum
+        self.bias_v += self.d_bias_v
+
+        self.d_bias_h = self.learning_rate * np.mean(h0 - h1, axis=0)\
+                        + self.d_bias_h * self.momentum
+        self.bias_h += self.d_bias_h
 
     def untwine_weights(self):
         """Decouple weight matrix"""

--- a/lab4/code/rbm.py
+++ b/lab4/code/rbm.py
@@ -193,7 +193,7 @@ class RestrictedBoltzmannMachine():
             self.update_params(X_batch, ph_prob, v_state, nh_prob)
 
             # Monitor the updates
-            if it % n_it_per_epoch == 0:
+            if it % n_it_per_epoch == 0 and it != 0:
                 end = time.time()
                 if self.is_top:
                     print((f'Epoch {epoch}/{int(n_epochs - 1)}: recon. err = '
@@ -202,14 +202,13 @@ class RestrictedBoltzmannMachine():
                     print((f'Epoch {epoch}/{int(n_epochs - 1)}: recon. err = '
                         f'{round(np.linalg.norm(X - V), 2)}'))
 
-                # Visualize once in a while when visible layer is input images
+                # Visualize once per epoch when visible layer is input images
                 if self.is_bottom:
                     viz_rf(weights=self.weight_vh[:, self.rf["ids"]].reshape(
                         (self.image_size[0], self.image_size[1], -1)), it=it,
                         grid=self.rf["grid"])
 
-                if it != 0:
-                    print(f'This epoch took {round(end - start, 2)} seconds to run.\n')
+                print(f'This epoch took {round(end - start, 2)} seconds to run.\n')
 
                 # Restart the time
                 start = time.time()

--- a/lab4/code/rbm.py
+++ b/lab4/code/rbm.py
@@ -190,14 +190,14 @@ class RestrictedBoltzmannMachine():
 
             # Activate and sample hidden units again, based on generated visible
             # state
-            nh_prob, _ = self.get_h_given_v(v_state)
+            nh_prob, nh_state = self.get_h_given_v(v_state)
 
             # Reconstruct the complete hidden layer only during the last epoch
             if epoch == n_epochs-1:
                self.H[mb_start:mb_end, :] = nh_prob
 
             # Updating parameters
-            self.update_params(X_batch, ph_prob, v_state, nh_prob)
+            self.update_params(X_batch, ph_state, v_state, nh_state)
 
             # Monitor the updates
             if it % n_it_per_epoch == 0 and it != 0:

--- a/lab4/code/rbm.py
+++ b/lab4/code/rbm.py
@@ -262,11 +262,11 @@ class RestrictedBoltzmannMachine():
         self.weight_vh = None
 
 
-    def get_h_given_v(self, X_batch, directed=False, direction="up"):
+    def get_h_given_v(self, v, directed=False, direction="up"):
         """Compute probabilities p(h|v) and activations h ~ p(h|v)
 
         Args:
-            X_batch (np.ndarray): (size of mini-batch, size of visible layer)
+            v (np.ndarray): Units of the visible layer
             directed (bool): Whether to use weight_v_to_h or weight_vh
             direction (str): One of "up" or "down"
 
@@ -277,14 +277,14 @@ class RestrictedBoltzmannMachine():
                                   (size mini-batch, size hidden layer)
         """
         if not directed:
-            h_prob = self._sigmoid(self.bias_h + np.dot(X_batch, self.weight_vh))
+            h_prob = self._sigmoid(self.bias_h + np.dot(v, self.weight_vh))
         else:
             if direction == "up":
                 h_prob = self._sigmoid(self.bias_h + np.dot(
-                    X_batch, self.weight_v_to_h))
+                    v, self.weight_v_to_h))
             elif direction == "down":
                 h_prob = self._sigmoid(self.bias_h + np.dot(
-                    X_batch, self.weight_h_to_v))
+                    v, self.weight_h_to_v))
             else:
                 raise ValueError("Input argument <directed> has to be either 'up' or 'down'.")
 
@@ -293,11 +293,11 @@ class RestrictedBoltzmannMachine():
         return h_prob, h_state
 
 
-    def get_v_given_h(self, H_batch, directed=False, direction="up"):
+    def get_v_given_h(self, h, directed=False, direction="up"):
         """Compute probabilities p(v|h) and activations v ~ p(v|h)
 
         Args:
-           H_batch: shape is (size of mini-batch, size of hidden layer)
+            h: Units of the hidden layer
             directed (bool): Whether to use weight_v_to_h or weight_vh
             direction (str): One of "up" or "down"
 
@@ -308,7 +308,7 @@ class RestrictedBoltzmannMachine():
         """
         if self.is_top:
             # Separate H_batch into the data support and labels support
-            support = self.bias_v + np.dot(H_batch, self.weight_vh.T)
+            support = self.bias_v + np.dot(h, self.weight_vh.T)
             support_data = support[:, :-self.n_labels]
             support_labels = support[:, -self.n_labels:]
 
@@ -326,15 +326,15 @@ class RestrictedBoltzmannMachine():
 
         else:
             if not directed:
-                v_prob = self._sigmoid(self.bias_v + np.dot(H_batch,
+                v_prob = self._sigmoid(self.bias_v + np.dot(h,
                     self.weight_vh.T))
             else:
                 if direction == "up":
                     v_prob = self._sigmoid(self.bias_v + np.dot(
-                        H_batch, self.weight_v_to_h))
+                        h, self.weight_v_to_h))
                 elif direction == "down":
                     v_prob = self._sigmoid(self.bias_v + np.dot(
-                        H_batch, self.weight_h_to_v))
+                        h, self.weight_h_to_v))
                 else:
                     raise ValueError("Input argument <directed> has to be either 'up' or 'down'.")
 

--- a/lab4/code/rbm.py
+++ b/lab4/code/rbm.py
@@ -83,6 +83,7 @@ class RestrictedBoltzmannMachine():
         Returns:
             (np.ndarray): on_probabilities (size of mini-batch, size of layer)
         """
+        support[support < -700] = -700
         return 1. / (1. + np.exp(-support))
 
 

--- a/lab4/code/rbm.py
+++ b/lab4/code/rbm.py
@@ -213,10 +213,6 @@ class RestrictedBoltzmannMachine():
                 # Restart the time
                 start = time.time()
 
-                # Reshuffle the data so that we don't always have the same
-                # mini-batches
-                np.random.shuffle(X)
-
                 epoch += 1
 
 

--- a/lab4/code/rbm.py
+++ b/lab4/code/rbm.py
@@ -323,3 +323,27 @@ class RestrictedBoltzmannMachine():
 
         return v_prob, v_state
 
+
+    def update_generate_params(self, y, x, y_hat):
+        """Update generative weight "weight_h_to_v" and bias "bias_v"
+            This is done during the wake-phase, a.k.a. going up
+        Args:
+            y (np.ndarray): activities or probabilities of input unit
+            x (np.ndarray): activities or probabilities of output unit (target)
+            y_hat (np.ndarray): activities or probabilities of output unit (prediction)
+        """
+        self.weight_h_to_v += self.learning_rate * np.dot(x.T,  (y - y_hat))
+        self.bias_v += self.learning_rate * np.mean(y - y_hat)
+
+
+    def update_recognize_params(self, y, x, y_hat):
+        """Update recognition weight "weight_v_to_h" and bias "bias_h"
+            This is done during the sleep-phase, a.k.a. going down
+        Args:
+            y (np.ndarray): activities or probabilities of input unit
+            x (np.ndarray): activities or probabilities of output unit (target)
+            y_hat (np.ndarray): activities or probabilities of output unit (prediction)
+        """
+        self.weight_v_to_h += self.learning_rate * np.dot(x.T, (y - y_hat))
+        self.bias_h += self.learning_rate * np.mean(y - y_hat)
+

--- a/lab4/code/rbm.py
+++ b/lab4/code/rbm.py
@@ -96,7 +96,8 @@ class RestrictedBoltzmannMachine():
         Returns:
             (np.ndarray): on_probabilities (size of mini-batch, number of categories)
         """
-        return np.exp(support - np.sum(support, axis=1)[:, None])
+        expsup = np.exp(support - np.sum(support, axis=1)[:, None])
+        return expsup / np.sum(expsup, axis=1)[:, None]
 
 
     @staticmethod

--- a/lab4/code/rbm.py
+++ b/lab4/code/rbm.py
@@ -141,7 +141,7 @@ class RestrictedBoltzmannMachine():
         return activations
 
 
-    def cd1(self, X, n_iterations=10000):
+    def cd1(self, X, n_iterations=10000, compute_rec_err=False):
         """Contrastive Divergence with k=1 full alternating Gibbs sampling
 
         Args:
@@ -149,6 +149,7 @@ class RestrictedBoltzmannMachine():
                             shape is (num_images, ndim_visible)
             n_iterations (int): number of iterations of learning (each iteration
                                 learns a mini-batch)
+            compute_rec_err (bool): Whether to compute the reconstruction error
 
         Note: if using 60,000 MNIST data points with a mini-batch size of 20,
               n_iterations=30000 means that we have 10 training epochs. Why?
@@ -165,6 +166,9 @@ class RestrictedBoltzmannMachine():
 
         # We want to regenerate the complete visual and hidden layers
         V, self.H = np.zeros(X.shape), np.zeros((n_samples, self.ndim_hidden))
+
+        if compute_rec_err:
+            errors = []
 
         # Start timing
         start = time.time()
@@ -201,9 +205,13 @@ class RestrictedBoltzmannMachine():
                 if self.is_top:
                     print((f'Epoch {epoch}/{int(n_epochs - 1)}: recon. err = '
                         f'{round(np.linalg.norm(X[:, :-10] - V[:, :-10]), 2)}'))
+                    if compute_rec_err:
+                        errors.append(round(np.linalg.norm(X[:, :-10] - V[:, :-10]), 2))
                 else:
                     print((f'Epoch {epoch}/{int(n_epochs - 1)}: recon. err = '
                         f'{round(np.linalg.norm(X - V), 2)}'))
+                    if compute_rec_err:
+                        errors.append(round(np.linalg.norm(X - V), 2))
 
                 # Visualize once per epoch when visible layer is input images
                 if self.is_bottom:
@@ -217,6 +225,9 @@ class RestrictedBoltzmannMachine():
                 start = time.time()
 
                 epoch += 1
+
+        if compute_rec_err:
+            return errors
 
 
     def update_params(self, v0, h0, v1, h1):

--- a/lab4/code/rbm.py
+++ b/lab4/code/rbm.py
@@ -60,7 +60,7 @@ class RestrictedBoltzmannMachine():
         self.d_weight_vh = np.zeros((self.ndim_visible,self.ndim_hidden))
         self.d_bias_v = np.zeros((self.ndim_visible))
         self.d_bias_h = np.zeros((self.ndim_hidden))
-        self.momentum = 0
+        self.momentum = 0.7
         self.learning_rate = learning_rate
         self.image_size = image_size
 

--- a/lab4/code/run.py
+++ b/lab4/code/run.py
@@ -18,8 +18,9 @@ from dbn import DeepBeliefNet
 PLOTS = False
 RBM = False
 DBN = True
-CLASSIFY = False
+CLASSIFY = True
 GENERATE = True
+WAKE_SLEEP = True
 
 if __name__ == "__main__":
     # Fix the dimensions of the images
@@ -70,7 +71,7 @@ if __name__ == "__main__":
 
         # Greedy layer-wise training
         dbn.train_greedylayerwise(X=train_imgs, y=train_lbls,
-                n_iterations=60000, load_from_file=True)
+                n_iterations=60000, save_fig=True)
 
         if CLASSIFY:
             # Recognize/Classify images
@@ -78,26 +79,29 @@ if __name__ == "__main__":
             dbn.recognize(test_imgs, test_lbls)
 
         if GENERATE:
-            # Change this to a higher number for more accurately generated images
-            # Ideally, this value would be set to 60,000
-            n_input_images = 100
-
             # Generate prototyical digits
             for digit in range(10):
                 digit_1hot = np.zeros(shape=(1, 10))
                 digit_1hot[0, digit] = 1
-                dbn.generate(X=train_imgs[:n_input_images], y=digit_1hot, name="rbms")
+                # Initialize based on a random training input
+                # (In this case we always use the first training image)
+                dbn.generate(X=train_imgs[0], y=digit_1hot, name="greedy")
 
-    if False:
+    if WAKE_SLEEP:
         # Fine-tune wake-sleep training
-        dbn.train_wakesleep_finetune(vis_trainset=train_imgs, lbl_trainset=train_lbls,
-                n_iterations=2000)
+        dbn.train_wakesleep_finetune(X=train_imgs, y=train_lbls,
+                n_iterations=16, save_to_file=True)
 
-        dbn.recognize(train_imgs, train_lbls)
-        dbn.recognize(test_imgs, test_lbls)
+        if CLASSIFY:
+            dbn.recognize(train_imgs, train_lbls)
+            dbn.recognize(test_imgs, test_lbls)
 
-        for digit in range(10):
-            digit_1hot = np.zeros(shape=(1, 10))
-            digit_1hot[0, digit] = 1
-            dbn.generate(digit_1hot, name="dbn")
+        if GENERATE:
+            # Generate prototyical digits
+            for digit in range(10):
+                digit_1hot = np.zeros(shape=(1, 10))
+                digit_1hot[0, digit] = 1
+                # Initialize based on a random training input
+                # (In this case we always use the first training image)
+                dbn.generate(X=train_imgs[0], y=digit_1hot, name="fine")
 

--- a/lab4/code/run.py
+++ b/lab4/code/run.py
@@ -71,7 +71,7 @@ if __name__ == "__main__":
 
         # Greedy layer-wise training
         dbn.train_greedylayerwise(X=train_imgs, y=train_lbls,
-                n_iterations=60000, save_fig=True)
+                n_iterations=60000, compute_rec_err=True)
 
         if CLASSIFY:
             # Recognize/Classify images

--- a/lab4/code/run.py
+++ b/lab4/code/run.py
@@ -18,6 +18,8 @@ from dbn import DeepBeliefNet
 PLOTS = False
 RBM = False
 DBN = True
+CLASSIFY = False
+GENERATE = True
 
 if __name__ == "__main__":
     # Fix the dimensions of the images
@@ -68,20 +70,25 @@ if __name__ == "__main__":
 
         # Greedy layer-wise training
         dbn.train_greedylayerwise(X=train_imgs, y=train_lbls,
-                n_iterations=60000, save_to_file=True)
+                n_iterations=60000, load_from_file=True)
 
-        dbn.recognize(X=test_imgs, y=test_lbls)
+        if CLASSIFY:
+            # Recognize/Classify images
+            dbn.recognize(train_imgs, train_lbls)
+            dbn.recognize(test_imgs, test_lbls)
 
-    # This has not been implemented yet
+        if GENERATE:
+            # Change this to a higher number for more accurately generated images
+            # Ideally, this value would be set to 60,000
+            n_input_images = 100
+
+            # Generate prototyical digits
+            for digit in range(10):
+                digit_1hot = np.zeros(shape=(1, 10))
+                digit_1hot[0, digit] = 1
+                dbn.generate(X=train_imgs[:n_input_images], y=digit_1hot, name="rbms")
+
     if False:
-        dbn.recognize(train_imgs, train_lbls)
-        dbn.recognize(test_imgs, test_lbls)
-
-        for digit in range(10):
-            digit_1hot = np.zeros(shape=(1, 10))
-            digit_1hot[0, digit] = 1
-            dbn.generate(digit_1hot, name="rbms")
-
         # Fine-tune wake-sleep training
         dbn.train_wakesleep_finetune(vis_trainset=train_imgs, lbl_trainset=train_lbls,
                 n_iterations=2000)

--- a/lab4/code/run.py
+++ b/lab4/code/run.py
@@ -67,9 +67,10 @@ if __name__ == "__main__":
             image_size=image_size, n_labels=10, batch_size=10)
 
         # Greedy layer-wise training
-        dbn.train_greedylayerwise(vis_trainset=train_imgs[:4000, :],
-                lbl_trainset=train_lbls[:4000, :],
-                n_iterations=2000)
+        dbn.train_greedylayerwise(X=train_imgs, y=train_lbls,
+                n_iterations=60000, save_to_file=True)
+
+        dbn.recognize(X=test_imgs, y=test_lbls)
 
     # This has not been implemented yet
     if False:

--- a/lab4/code/run.py
+++ b/lab4/code/run.py
@@ -16,6 +16,8 @@ from rbm import RestrictedBoltzmannMachine
 from dbn import DeepBeliefNet
 
 PLOTS = False
+RBM = False
+DBN = True
 
 if __name__ == "__main__":
     # Fix the dimensions of the images
@@ -46,28 +48,31 @@ if __name__ == "__main__":
             plot_digit(train_imgs[i], train_lbls_digits[i])
 
 
-    # Restricted Boltzmann Machine
-    print ("\nStarting a Restricted Boltzmann Machine...")
+    if RBM:
+        # Restricted Boltzmann Machine
+        print ("\nStarting a Restricted Boltzmann Machine...")
 
-    rbm = RestrictedBoltzmannMachine(ndim_visible=image_size[0] * image_size[1],
-            ndim_hidden=200, is_bottom=True, image_size=image_size, is_top=False,
-            n_labels=10, batch_size=20, learning_rate=0.1)
+        rbm = RestrictedBoltzmannMachine(ndim_visible=image_size[0] * image_size[1],
+                ndim_hidden=200, is_bottom=True, image_size=image_size, is_top=False,
+                n_labels=10, batch_size=20, learning_rate=0.1)
 
-    rbm.cd1(X=train_imgs, n_iterations=30000)
+        rbm.cd1(X=train_imgs, n_iterations=30000)
 
-    # We do not always want to run everything in this main file
-    if False:
+    if DBN:
         # Deep Belief Net
-        print ("\nStarting a Deep Belief Net...")
+        print ("\n>>> Starting a Deep Belief Net...")
 
-        dbn = DeepBeliefNet(sizes={"vis":image_size[0]*image_size[1], "hid":500,
-            "pen":500, "top":2000, "lbl":10}, image_size=image_size, n_labels=10,
-            batch_size=10)
+        dbn = DeepBeliefNet(sizes={"vis": image_size[0] * image_size[1],
+            "hid": 500, "pen": 500, "top": 2000, "lbl": 10},
+            image_size=image_size, n_labels=10, batch_size=10)
 
         # Greedy layer-wise training
-        dbn.train_greedylayerwise(vis_trainset=train_imgs, lbl_trainset=train_lbls,
+        dbn.train_greedylayerwise(vis_trainset=train_imgs[:4000, :],
+                lbl_trainset=train_lbls[:4000, :],
                 n_iterations=2000)
 
+    # This has not been implemented yet
+    if False:
         dbn.recognize(train_imgs, train_lbls)
         dbn.recognize(test_imgs, test_lbls)
 

--- a/lab4/code/util.py
+++ b/lab4/code/util.py
@@ -145,3 +145,22 @@ def plot_digit(d_arr, label):
     plt.title(f'Digit: {label}')
     plt.show()
 
+
+def plot_reconstruction_err(errors, fname="", save_fig=False):
+    """Plots the reconstruction errors over epochs
+
+    Args:
+        fname (str): File name for saving
+        save_fig (bool): Whether to save the plot
+    """
+
+    for i, _ in enumerate(errors):
+        plt.plot(range(len(errors[0])), errors[i],
+                label=f"Reconstruction Error Layer {i+1}")
+
+    plt.legend()
+    plt.title("The reconstruction errors over the epochs")
+    plt.xlabel("Epochs")
+    plt.ylabel("Reconstruction error")
+    if save_fig: plt.savefig(fname)
+    plt.show()


### PR DESCRIPTION
This branch contains the full implementation for lab 4 part 2, and can therefore be merged with master.
Afterwards, the lab4/part2 branch can be deleted.

This branch contains the following:

-  A working implementation of the wake-sleep algorithm. The fine-tuning improves bot classification accuracy and image generation.
- Working implementations for momentum learning and weight decay for both the contrastive divergence and the wake-sleep algorithm.
- An updated ```run.py```. If ```$ python3 run.py``` is run, a DBN will be greedily trained on the whole data set, both the training and test accuracies for classification will be computed and digits will be generated. Afterwards, the model will be fine-tuned using the wake-sleep algorithm, the classification accuracy will be computed anew, and new digits will be generated.